### PR TITLE
chore: replace TensoRaws org URLs with EutropicAI

### DIFF
--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           version: 10
 
-      - name: fetch VSET-core # fetch VSET-core from https://github.com/TensoRaws/VSET-core/releases
+      - name: fetch VSET-core # fetch VSET-core from https://github.com/EutropicAI/VSET-core/releases
         run: |
           cd resources
-          $baseUrl = "https://github.com/TensoRaws/VSET-core/releases/download/v4.2-0819"
+          $baseUrl = "https://github.com/EutropicAI/VSET-core/releases/download/v4.2-0819"
           1..4 | ForEach-Object {
               $url = "$baseUrl/VSET-core.7z.00$_"
               Write-Host "Downloading $url ..."

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -32,10 +32,10 @@ jobs:
         with:
           version: 10
 
-      - name: fetch VSET-core # fetch VSET-core from https://github.com/TensoRaws/VSET-core/releases
+      - name: fetch VSET-core # fetch VSET-core from https://github.com/EutropicAI/VSET-core/releases
         run: |
           cd resources
-          $baseUrl = "https://github.com/TensoRaws/VSET-core/releases/download/v4.2-0819"
+          $baseUrl = "https://github.com/EutropicAI/VSET-core/releases/download/v4.2-0819"
           1..4 | ForEach-Object {
               $url = "$baseUrl/VSET-core.7z.00$_"
               Write-Host "Downloading $url ..."

--- a/src/renderer/src/utils/getVpy.ts
+++ b/src/renderer/src/utils/getVpy.ts
@@ -70,7 +70,7 @@ These magic strings will be replaced in final script:
     - Video Path: __VIDEO_PATH__
     - Extra Model Path: __EXTRA_MODEL_PATH__
 
-GitHub: https://github.com/TensoRaws/VSET
+GitHub: https://github.com/EutropicAI/VSET
 """
 \n
 `


### PR DESCRIPTION
We renamed the organization. This PR updates occurrences of:
- https://github.com/TensoRaws
to:
- https://github.com/EutropicAI

Notes:
- Only text-like files were modified; common binary/build paths skipped.
- Please review and merge when ready.
