### PR TITLE
chore: replace org URLs and LICENSE links

### DIFF
--- a/.github/workflows/CI-build.yml
+++ b/.github/workflows/CI-build.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           version: 10
 
-      - name: fetch VSET-core # fetch VSET-core from https://github.com/TensoRaws/VSET-core/releases
+      - name: fetch VSET-core # fetch VSET-core from https://github.com/EutropicAI/VSET-core/releases
         run: |
           cd resources
-          $baseUrl = "https://github.com/TensoRaws/VSET-core/releases/download/v4.2-0819"
+          $baseUrl = "https://github.com/EutropicAI/VSET-core/releases/download/v4.2-0819"
           1..4 | ForEach-Object {
               $url = "$baseUrl/VSET-core.7z.00$_"
               Write-Host "Downloading $url ..."

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -32,10 +32,10 @@ jobs:
         with:
           version: 10
 
-      - name: fetch VSET-core # fetch VSET-core from https://github.com/TensoRaws/VSET-core/releases
+      - name: fetch VSET-core # fetch VSET-core from https://github.com/EutropicAI/VSET-core/releases
         run: |
           cd resources
-          $baseUrl = "https://github.com/TensoRaws/VSET-core/releases/download/v4.2-0819"
+          $baseUrl = "https://github.com/EutropicAI/VSET-core/releases/download/v4.2-0819"
           1..4 | ForEach-Object {
               $url = "$baseUrl/VSET-core.7z.00$_"
               Write-Host "Downloading $url ..."

--- a/src/renderer/src/utils/getVpy.ts
+++ b/src/renderer/src/utils/getVpy.ts
@@ -70,7 +70,7 @@ These magic strings will be replaced in final script:
     - Video Path: __VIDEO_PATH__
     - Extra Model Path: __EXTRA_MODEL_PATH__
 
-GitHub: https://github.com/TensoRaws/VSET
+GitHub: https://github.com/EutropicAI/VSET
 """
 \n
 `


### PR DESCRIPTION
This PR updates explicit org URLs and converts absolute LICENSE links to relative form.

Org URL replacements: 5
LICENSE link conversions (blob): 0
LICENSE link conversions (raw): 0

Old base: TensoRaws
New base: EutropicAI

Relative ./LICENSE links stay correct if branches or hosts change.